### PR TITLE
Change callbacks to return specific response types

### DIFF
--- a/examples/http_auth_random.rs
+++ b/examples/http_auth_random.rs
@@ -26,7 +26,7 @@ pub fn _start() {
 struct HttpAuthRandom;
 
 impl HttpContext for HttpAuthRandom {
-    fn on_http_request_headers(&mut self, _: usize) -> Action {
+    fn on_http_request_headers(&mut self, _: usize) -> FilterHeadersStatus {
         self.dispatch_http_call(
             "httpbin",
             vec![
@@ -39,12 +39,12 @@ impl HttpContext for HttpAuthRandom {
             Duration::from_secs(5),
         )
         .unwrap();
-        Action::Pause
+        FilterHeadersStatus::StopIteration
     }
 
-    fn on_http_response_headers(&mut self, _: usize) -> Action {
+    fn on_http_response_headers(&mut self, _: usize) -> FilterHeadersStatus {
         self.set_http_response_header("Powered-By", Some("proxy-wasm"));
-        Action::Continue
+        FilterHeadersStatus::Continue
     }
 }
 

--- a/examples/http_headers.rs
+++ b/examples/http_headers.rs
@@ -31,7 +31,7 @@ struct HttpHeaders {
 impl Context for HttpHeaders {}
 
 impl HttpContext for HttpHeaders {
-    fn on_http_request_headers(&mut self, _: usize) -> Action {
+    fn on_http_request_headers(&mut self, _: usize) -> FilterHeadersStatus {
         for (name, value) in &self.get_http_request_headers() {
             trace!("#{} -> {}: {}", self.context_id, name, value);
         }
@@ -43,17 +43,17 @@ impl HttpContext for HttpHeaders {
                     vec![("Hello", "World"), ("Powered-By", "proxy-wasm")],
                     Some(b"Hello, World!\n"),
                 );
-                Action::Pause
+                FilterHeadersStatus::StopIteration
             }
-            _ => Action::Continue,
+            _ => FilterHeadersStatus::Continue,
         }
     }
 
-    fn on_http_response_headers(&mut self, _: usize) -> Action {
+    fn on_http_response_headers(&mut self, _: usize) -> FilterHeadersStatus {
         for (name, value) in &self.get_http_response_headers() {
             trace!("#{} <- {}: {}", self.context_id, name, value);
         }
-        Action::Continue
+        FilterHeadersStatus::Continue
     }
 
     fn on_log(&mut self) {

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -229,7 +229,7 @@ impl Dispatcher {
         }
     }
 
-    fn on_new_connection(&self, context_id: u32) -> Action {
+    fn on_new_connection(&self, context_id: u32) -> FilterStatus {
         if let Some(stream) = self.streams.borrow_mut().get_mut(&context_id) {
             self.active_id.set(context_id);
             stream.on_new_connection()
@@ -238,7 +238,7 @@ impl Dispatcher {
         }
     }
 
-    fn on_downstream_data(&self, context_id: u32, data_size: usize, end_of_stream: bool) -> Action {
+    fn on_downstream_data(&self, context_id: u32, data_size: usize, end_of_stream: bool) -> FilterStatus {
         if let Some(stream) = self.streams.borrow_mut().get_mut(&context_id) {
             self.active_id.set(context_id);
             stream.on_downstream_data(data_size, end_of_stream)
@@ -256,7 +256,7 @@ impl Dispatcher {
         }
     }
 
-    fn on_upstream_data(&self, context_id: u32, data_size: usize, end_of_stream: bool) -> Action {
+    fn on_upstream_data(&self, context_id: u32, data_size: usize, end_of_stream: bool) -> FilterStatus {
         if let Some(stream) = self.streams.borrow_mut().get_mut(&context_id) {
             self.active_id.set(context_id);
             stream.on_upstream_data(data_size, end_of_stream)
@@ -274,7 +274,7 @@ impl Dispatcher {
         }
     }
 
-    fn on_http_request_headers(&self, context_id: u32, num_headers: usize) -> Action {
+    fn on_http_request_headers(&self, context_id: u32, num_headers: usize) -> FilterHeadersStatus {
         if let Some(http_stream) = self.http_streams.borrow_mut().get_mut(&context_id) {
             self.active_id.set(context_id);
             http_stream.on_http_request_headers(num_headers)
@@ -288,7 +288,7 @@ impl Dispatcher {
         context_id: u32,
         body_size: usize,
         end_of_stream: bool,
-    ) -> Action {
+    ) -> FilterDataStatus {
         if let Some(http_stream) = self.http_streams.borrow_mut().get_mut(&context_id) {
             self.active_id.set(context_id);
             http_stream.on_http_request_body(body_size, end_of_stream)
@@ -297,7 +297,7 @@ impl Dispatcher {
         }
     }
 
-    fn on_http_request_trailers(&self, context_id: u32, num_trailers: usize) -> Action {
+    fn on_http_request_trailers(&self, context_id: u32, num_trailers: usize) -> FilterTrailersStatus {
         if let Some(http_stream) = self.http_streams.borrow_mut().get_mut(&context_id) {
             self.active_id.set(context_id);
             http_stream.on_http_request_trailers(num_trailers)
@@ -306,7 +306,7 @@ impl Dispatcher {
         }
     }
 
-    fn on_http_response_headers(&self, context_id: u32, num_headers: usize) -> Action {
+    fn on_http_response_headers(&self, context_id: u32, num_headers: usize) -> FilterHeadersStatus {
         if let Some(http_stream) = self.http_streams.borrow_mut().get_mut(&context_id) {
             self.active_id.set(context_id);
             http_stream.on_http_response_headers(num_headers)
@@ -320,7 +320,7 @@ impl Dispatcher {
         context_id: u32,
         body_size: usize,
         end_of_stream: bool,
-    ) -> Action {
+    ) -> FilterDataStatus {
         if let Some(http_stream) = self.http_streams.borrow_mut().get_mut(&context_id) {
             self.active_id.set(context_id);
             http_stream.on_http_response_body(body_size, end_of_stream)
@@ -329,7 +329,7 @@ impl Dispatcher {
         }
     }
 
-    fn on_http_response_trailers(&self, context_id: u32, num_trailers: usize) -> Action {
+    fn on_http_response_trailers(&self, context_id: u32, num_trailers: usize) -> FilterTrailersStatus {
         if let Some(http_stream) = self.http_streams.borrow_mut().get_mut(&context_id) {
             self.active_id.set(context_id);
             http_stream.on_http_response_trailers(num_trailers)
@@ -406,7 +406,7 @@ pub extern "C" fn proxy_on_queue_ready(context_id: u32, queue_id: u32) {
 }
 
 #[no_mangle]
-pub extern "C" fn proxy_on_new_connection(context_id: u32) -> Action {
+pub extern "C" fn proxy_on_new_connection(context_id: u32) -> FilterStatus {
     DISPATCHER.with(|dispatcher| dispatcher.on_new_connection(context_id))
 }
 
@@ -415,7 +415,7 @@ pub extern "C" fn proxy_on_downstream_data(
     context_id: u32,
     data_size: usize,
     end_of_stream: bool,
-) -> Action {
+) -> FilterStatus {
     DISPATCHER
         .with(|dispatcher| dispatcher.on_downstream_data(context_id, data_size, end_of_stream))
 }
@@ -430,7 +430,7 @@ pub extern "C" fn proxy_on_upstream_data(
     context_id: u32,
     data_size: usize,
     end_of_stream: bool,
-) -> Action {
+) -> FilterStatus {
     DISPATCHER.with(|dispatcher| dispatcher.on_upstream_data(context_id, data_size, end_of_stream))
 }
 
@@ -440,7 +440,7 @@ pub extern "C" fn proxy_on_upstream_connection_close(context_id: u32, peer_type:
 }
 
 #[no_mangle]
-pub extern "C" fn proxy_on_request_headers(context_id: u32, num_headers: usize) -> Action {
+pub extern "C" fn proxy_on_request_headers(context_id: u32, num_headers: usize) -> FilterHeadersStatus {
     DISPATCHER.with(|dispatcher| dispatcher.on_http_request_headers(context_id, num_headers))
 }
 
@@ -449,18 +449,18 @@ pub extern "C" fn proxy_on_request_body(
     context_id: u32,
     body_size: usize,
     end_of_stream: bool,
-) -> Action {
+) -> FilterDataStatus {
     DISPATCHER
         .with(|dispatcher| dispatcher.on_http_request_body(context_id, body_size, end_of_stream))
 }
 
 #[no_mangle]
-pub extern "C" fn proxy_on_request_trailers(context_id: u32, num_trailers: usize) -> Action {
+pub extern "C" fn proxy_on_request_trailers(context_id: u32, num_trailers: usize) -> FilterTrailersStatus {
     DISPATCHER.with(|dispatcher| dispatcher.on_http_request_trailers(context_id, num_trailers))
 }
 
 #[no_mangle]
-pub extern "C" fn proxy_on_response_headers(context_id: u32, num_headers: usize) -> Action {
+pub extern "C" fn proxy_on_response_headers(context_id: u32, num_headers: usize) -> FilterHeadersStatus {
     DISPATCHER.with(|dispatcher| dispatcher.on_http_response_headers(context_id, num_headers))
 }
 
@@ -469,13 +469,13 @@ pub extern "C" fn proxy_on_response_body(
     context_id: u32,
     body_size: usize,
     end_of_stream: bool,
-) -> Action {
+) -> FilterDataStatus {
     DISPATCHER
         .with(|dispatcher| dispatcher.on_http_response_body(context_id, body_size, end_of_stream))
 }
 
 #[no_mangle]
-pub extern "C" fn proxy_on_response_trailers(context_id: u32, num_trailers: usize) -> Action {
+pub extern "C" fn proxy_on_response_trailers(context_id: u32, num_trailers: usize) -> FilterTrailersStatus {
     DISPATCHER.with(|dispatcher| dispatcher.on_http_response_trailers(context_id, num_trailers))
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -124,12 +124,12 @@ pub trait RootContext: Context {
 }
 
 pub trait StreamContext: Context {
-    fn on_new_connection(&mut self) -> Action {
-        Action::Continue
+    fn on_new_connection(&mut self) -> FilterStatus {
+        FilterStatus::Continue
     }
 
-    fn on_downstream_data(&mut self, _data_size: usize, _end_of_stream: bool) -> Action {
-        Action::Continue
+    fn on_downstream_data(&mut self, _data_size: usize, _end_of_stream: bool) -> FilterStatus {
+        FilterStatus::Continue
     }
 
     fn get_downstream_data(&self, start: usize, max_size: usize) -> Option<Bytes> {
@@ -142,8 +142,8 @@ pub trait StreamContext: Context {
 
     fn on_downstream_close(&mut self, _peer_type: PeerType) {}
 
-    fn on_upstream_data(&mut self, _data_size: usize, _end_of_stream: bool) -> Action {
-        Action::Continue
+    fn on_upstream_data(&mut self, _data_size: usize, _end_of_stream: bool) -> FilterStatus {
+        FilterStatus::Continue
     }
 
     fn get_upstream_data(&self, start: usize, max_size: usize) -> Option<Bytes> {
@@ -160,8 +160,8 @@ pub trait StreamContext: Context {
 }
 
 pub trait HttpContext: Context {
-    fn on_http_request_headers(&mut self, _num_headers: usize) -> Action {
-        Action::Continue
+    fn on_http_request_headers(&mut self, _num_headers: usize) -> FilterHeadersStatus {
+        FilterHeadersStatus::Continue
     }
 
     fn get_http_request_headers(&self) -> Vec<(String, String)> {
@@ -184,8 +184,12 @@ pub trait HttpContext: Context {
         hostcalls::add_map_value(MapType::HttpRequestHeaders, &name, value).unwrap()
     }
 
-    fn on_http_request_body(&mut self, _body_size: usize, _end_of_stream: bool) -> Action {
-        Action::Continue
+    fn on_http_request_body(
+        &mut self,
+        _body_size: usize,
+        _end_of_stream: bool,
+    ) -> FilterDataStatus {
+        FilterDataStatus::Continue
     }
 
     fn get_http_request_body(&self, start: usize, max_size: usize) -> Option<Bytes> {
@@ -196,8 +200,8 @@ pub trait HttpContext: Context {
         hostcalls::set_buffer(BufferType::HttpRequestBody, start, size, value).unwrap()
     }
 
-    fn on_http_request_trailers(&mut self, _num_trailers: usize) -> Action {
-        Action::Continue
+    fn on_http_request_trailers(&mut self, _num_trailers: usize) -> FilterTrailersStatus {
+        FilterTrailersStatus::Continue
     }
 
     fn get_http_request_trailers(&self) -> Vec<(String, String)> {
@@ -224,8 +228,8 @@ pub trait HttpContext: Context {
         hostcalls::resume_http_request().unwrap()
     }
 
-    fn on_http_response_headers(&mut self, _num_headers: usize) -> Action {
-        Action::Continue
+    fn on_http_response_headers(&mut self, _num_headers: usize) -> FilterHeadersStatus {
+        FilterHeadersStatus::Continue
     }
 
     fn get_http_response_headers(&self) -> Vec<(String, String)> {
@@ -248,8 +252,12 @@ pub trait HttpContext: Context {
         hostcalls::add_map_value(MapType::HttpResponseHeaders, &name, value).unwrap()
     }
 
-    fn on_http_response_body(&mut self, _body_size: usize, _end_of_stream: bool) -> Action {
-        Action::Continue
+    fn on_http_response_body(
+        &mut self,
+        _body_size: usize,
+        _end_of_stream: bool,
+    ) -> FilterDataStatus {
+        FilterDataStatus::Continue
     }
 
     fn get_http_response_body(&self, start: usize, max_size: usize) -> Option<Bytes> {
@@ -260,8 +268,8 @@ pub trait HttpContext: Context {
         hostcalls::set_buffer(BufferType::HttpResponseBody, start, size, value).unwrap()
     }
 
-    fn on_http_response_trailers(&mut self, _num_trailers: usize) -> Action {
-        Action::Continue
+    fn on_http_response_trailers(&mut self, _num_trailers: usize) -> FilterTrailersStatus {
+        FilterTrailersStatus::Continue
     }
 
     fn get_http_response_trailers(&self) -> Vec<(String, String)> {

--- a/src/types.rs
+++ b/src/types.rs
@@ -31,20 +31,60 @@ pub enum LogLevel {
 
 #[repr(u32)]
 #[derive(Debug)]
-pub enum Action {
+pub enum FilterStatus {
     Continue = 0,
-    Pause = 1,
+    StopIteration = 1,
 }
 
 #[repr(u32)]
 #[derive(Debug)]
+pub enum FilterHeadersStatus {
+    Continue = 0,
+    StopIteration = 1,
+    ContinueAndEndStream = 2,
+    StopAllIterationAndBuffer = 3,
+    StopAllIterationAndWatermark = 4,
+}
+
+#[repr(u32)]
+#[derive(Debug)]
+pub enum FilterMetadataStatus {
+    Continue = 0,
+}
+
+#[repr(u32)]
+#[derive(Debug)]
+pub enum FilterTrailersStatus {
+    Continue = 0,
+    StopIteration = 1,
+}
+
+#[repr(u32)]
+#[derive(Debug)]
+pub enum FilterDataStatus {
+    Continue = 0,
+    StopIterationAndBuffer = 1,
+    StopIterationAndWatermark = 2,
+    StopIterationNoBuffer = 3,
+}
+
+#[repr(u32)]
+#[non_exhaustive]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Status {
     Ok = 0,
     NotFound = 1,
     BadArgument = 2,
+    SerializationFailure = 3,
+    ParseFailure = 4,
+    BadExpression = 5,
+    InvalidMemoryAccess = 6,
     Empty = 7,
     CasMismatch = 8,
+    ResultMismatch = 9,
     InternalFailure = 10,
+    BrokenConnection = 11,
+    Unimplemented = 12,
 }
 
 #[repr(u32)]
@@ -55,6 +95,10 @@ pub enum BufferType {
     DownstreamData = 2,
     UpstreamData = 3,
     HttpCallResponseBody = 4,
+    GrpcReceiveBuffer = 5,
+    VmConfiguration = 6,
+    PluginConfiguration = 7,
+    CallData = 8,
 }
 
 #[repr(u32)]
@@ -64,6 +108,8 @@ pub enum MapType {
     HttpRequestTrailers = 1,
     HttpResponseHeaders = 2,
     HttpResponseTrailers = 3,
+    GrpcReceiveInitialMetadata = 4,
+    GrpcReceiveTrailingMetadata = 5,
     HttpCallResponseHeaders = 6,
     HttpCallResponseTrailers = 7,
 }


### PR DESCRIPTION
This replaces the "Action" enum that is used when returning from
the various callbacks to the specific callbacks types that are
also used by the C++ SDK, such as FilterHeadersStatus,
FilterDataStatus, and so on.

I understand that the original API was trying to present a somewhat simplified view of callbacks than the raw WASM ABI does, and that there are efforts to produce a better ABI. However, at the moment this change makes this SDK more understandable because it matches what internal Envoy code as well as the C++ SDK do, and since this is a low-level SDK, I think it should faithfully reproduce the whole ABI.