### PR TITLE
Update ahash (transitive dependency) to v0.4.7.

### DIFF
--- a/bazel/cargo/Cargo.lock
+++ b/bazel/cargo/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "ahash"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6789e291be47ace86a60303502173d84af8327e3627ecf334356ee0f87a164c"
+checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
 
 [[package]]
 name = "autocfg"

--- a/bazel/cargo/crates.bzl
+++ b/bazel/cargo/crates.bzl
@@ -13,12 +13,12 @@ def raze_fetch_remote_crates():
     """This function defines a collection of repos and should be called in a WORKSPACE file"""
     maybe(
         http_archive,
-        name = "raze__ahash__0_4_6",
-        url = "https://crates.io/api/v1/crates/ahash/0.4.6/download",
+        name = "raze__ahash__0_4_7",
+        url = "https://crates.io/api/v1/crates/ahash/0.4.7/download",
         type = "tar.gz",
-        sha256 = "f6789e291be47ace86a60303502173d84af8327e3627ecf334356ee0f87a164c",
-        strip_prefix = "ahash-0.4.6",
-        build_file = Label("//bazel/cargo/remote:BUILD.ahash-0.4.6.bazel"),
+        sha256 = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e",
+        strip_prefix = "ahash-0.4.7",
+        build_file = Label("//bazel/cargo/remote:BUILD.ahash-0.4.7.bazel"),
     )
 
     maybe(

--- a/bazel/cargo/remote/BUILD.ahash-0.4.7.bazel
+++ b/bazel/cargo/remote/BUILD.ahash-0.4.7.bazel
@@ -49,7 +49,7 @@ rust_library(
         "cargo-raze",
         "manual",
     ],
-    version = "0.4.6",
+    version = "0.4.7",
     # buildifier: leave-alone
     deps = [
     ],

--- a/bazel/cargo/remote/BUILD.hashbrown-0.9.1.bazel
+++ b/bazel/cargo/remote/BUILD.hashbrown-0.9.1.bazel
@@ -53,7 +53,7 @@ rust_library(
     version = "0.9.1",
     # buildifier: leave-alone
     deps = [
-        "@raze__ahash__0_4_6//:ahash",
+        "@raze__ahash__0_4_7//:ahash",
     ],
 )
 


### PR DESCRIPTION
Signed-off-by: Piotr Sikora <piotrsikora@google.com>