### PR TITLE
Introduce on_create_child_context hook for creating non root contexts

### DIFF
--- a/examples/http_auth_random.rs
+++ b/examples/http_auth_random.rs
@@ -20,7 +20,17 @@ use std::time::Duration;
 #[no_mangle]
 pub fn _start() {
     proxy_wasm::set_log_level(LogLevel::Trace);
-    proxy_wasm::set_http_context(|_, _| -> Box<dyn HttpContext> { Box::new(HttpAuthRandom) });
+    proxy_wasm::set_root_context(|_| -> Box<dyn RootContext> { Box::new(HttpAuthRandomRoot) });
+}
+
+struct HttpAuthRandomRoot;
+
+impl Context for HttpAuthRandomRoot {}
+
+impl RootContext for HttpAuthRandomRoot {
+    fn on_create_child_context(&mut self, _context_id: u32) -> Option<ChildContext> {
+        Some(ChildContext::HttpContext(Box::new(HttpAuthRandom)))
+    }
 }
 
 struct HttpAuthRandom;

--- a/examples/http_body.rs
+++ b/examples/http_body.rs
@@ -26,12 +26,8 @@ struct HttpBodyRoot;
 impl Context for HttpBodyRoot {}
 
 impl RootContext for HttpBodyRoot {
-    fn get_type(&self) -> Option<ContextType> {
-        Some(ContextType::HttpContext)
-    }
-
-    fn create_http_context(&self, _: u32) -> Option<Box<dyn HttpContext>> {
-        Some(Box::new(HttpBody))
+    fn on_create_child_context(&mut self, _context_id: u32) -> Option<ChildContext> {
+        Some(ChildContext::HttpContext(Box::new(HttpBody)))
     }
 }
 

--- a/examples/http_config.rs
+++ b/examples/http_config.rs
@@ -52,13 +52,9 @@ impl RootContext for HttpConfigHeaderRoot {
         true
     }
 
-    fn create_http_context(&self, _: u32) -> Option<Box<dyn HttpContext>> {
-        Some(Box::new(HttpConfigHeader {
+    fn on_create_child_context(&mut self, _context_id: u32) -> Option<ChildContext> {
+        Some(ChildContext::HttpContext(Box::new(HttpConfigHeader {
             header_content: self.header_content.clone(),
-        }))
-    }
-
-    fn get_type(&self) -> Option<ContextType> {
-        Some(ContextType::HttpContext)
+        })))
     }
 }

--- a/examples/http_headers.rs
+++ b/examples/http_headers.rs
@@ -27,12 +27,10 @@ struct HttpHeadersRoot;
 impl Context for HttpHeadersRoot {}
 
 impl RootContext for HttpHeadersRoot {
-    fn get_type(&self) -> Option<ContextType> {
-        Some(ContextType::HttpContext)
-    }
-
-    fn create_http_context(&self, context_id: u32) -> Option<Box<dyn HttpContext>> {
-        Some(Box::new(HttpHeaders { context_id }))
+    fn on_create_child_context(&mut self, context_id: u32) -> Option<ChildContext> {
+        Some(ChildContext::HttpContext(Box::new(HttpHeaders {
+            context_id,
+        })))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,13 +28,5 @@ pub fn set_root_context(callback: types::NewRootContext) {
     dispatcher::set_root_context(callback);
 }
 
-pub fn set_stream_context(callback: types::NewStreamContext) {
-    dispatcher::set_stream_context(callback);
-}
-
-pub fn set_http_context(callback: types::NewHttpContext) {
-    dispatcher::set_http_context(callback);
-}
-
 #[no_mangle]
 pub extern "C" fn proxy_abi_version_0_1_0() {}

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -122,6 +122,12 @@ pub trait RootContext: Context {
 
     fn on_log(&mut self) {}
 
+    fn on_create_child_context(&mut self, _context_id: u32) -> Option<ChildContext> {
+        // on_create_child_context has higher priority than any other methods
+        // for creating non root contexts
+        None
+    }
+
     fn create_http_context(&self, _context_id: u32) -> Option<Box<dyn HttpContext>> {
         None
     }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -123,20 +123,7 @@ pub trait RootContext: Context {
     fn on_log(&mut self) {}
 
     fn on_create_child_context(&mut self, _context_id: u32) -> Option<ChildContext> {
-        // on_create_child_context has higher priority than any other methods
-        // for creating non root contexts
-        None
-    }
-
-    fn create_http_context(&self, _context_id: u32) -> Option<Box<dyn HttpContext>> {
-        None
-    }
-
-    fn create_stream_context(&self, _context_id: u32) -> Option<Box<dyn StreamContext>> {
-        None
-    }
-
-    fn get_type(&self) -> Option<ContextType> {
+        // on_create_child_context is required to create non root contexts
         None
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -15,8 +15,6 @@
 use crate::traits::*;
 
 pub type NewRootContext = fn(context_id: u32) -> Box<dyn RootContext>;
-pub type NewStreamContext = fn(context_id: u32, root_context_id: u32) -> Box<dyn StreamContext>;
-pub type NewHttpContext = fn(context_id: u32, root_context_id: u32) -> Box<dyn HttpContext>;
 
 pub enum ChildContext {
     StreamContext(Box<dyn StreamContext>),
@@ -50,13 +48,6 @@ pub enum Status {
     Empty = 7,
     CasMismatch = 8,
     InternalFailure = 10,
-}
-
-#[repr(u32)]
-#[derive(Debug)]
-pub enum ContextType {
-    HttpContext = 0,
-    StreamContext = 1,
 }
 
 #[repr(u32)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -18,6 +18,11 @@ pub type NewRootContext = fn(context_id: u32) -> Box<dyn RootContext>;
 pub type NewStreamContext = fn(context_id: u32, root_context_id: u32) -> Box<dyn StreamContext>;
 pub type NewHttpContext = fn(context_id: u32, root_context_id: u32) -> Box<dyn HttpContext>;
 
+pub enum ChildContext {
+    StreamContext(Box<dyn StreamContext>),
+    HttpContext(Box<dyn HttpContext>),
+}
+
 #[repr(u32)]
 #[derive(Debug)]
 pub enum LogLevel {


### PR DESCRIPTION
This is based on previous work from @yskopets for creating child contexts via a hook in the root context (#6).

The patches first introduce the mechanism, then change the examples to make use of it, and finally remove the other currently existing methods in a **breaking** change to both simplify usage by having a single way to do this and clean up some of the code which should no longer be necessary. Compile-tested all examples after every patch.

Feel free to use or cherry pick partially or as needed.