### PR TITLE
logger: don't panic in the panic handler

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -26,7 +26,7 @@ pub(crate) fn set_log_level(level: LogLevel) {
     if !INITIALIZED.load(Ordering::Relaxed) {
         log::set_logger(&LOGGER).unwrap();
         panic::set_hook(Box::new(|panic_info| {
-            hostcalls::log(LogLevel::Critical, &panic_info.to_string()).unwrap();
+            let _ = hostcalls::log_nopanic(LogLevel::Critical, &panic_info.to_string());
         }));
         INITIALIZED.store(true, Ordering::Relaxed);
     }


### PR DESCRIPTION
This avoids a potential double-panic in the panic handler if the logging status code is not recognised.