### PR TITLE
Update cargo-raze to v0.11.0.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,10 +60,10 @@ jobs:
         key: ${{ hashFiles('WORKSPACE', '.bazelrc', '.bazelversion', 'bazel/cargo/Cargo.raze.lock', 'bazel/dependencies.bzl', 'bazel/repositories.bzl') }}
 
     - name: Build (wasm32-unknown-unknown)
-      run: bazelisk --bazelrc=/dev/null build --platforms=@rules_rust//rust/platform:wasm //...
+      run: bazelisk --noworkspace_rc build --platforms=@rules_rust//rust/platform:wasm //...
 
     - name: Build (wasm32-wasi)
-      run: bazelisk --bazelrc=/dev/null build --platforms=@rules_rust//rust/platform:wasi //...
+      run: bazelisk --noworkspace_rc build --platforms=@rules_rust//rust/platform:wasi //...
 
     - name: Format (buildifier)
       run: |
@@ -76,9 +76,7 @@ jobs:
     - name: Format (cargo raze)
       run: |
         mv bazel/cargo/Cargo.raze.lock Cargo.lock
-        rm -rf bazel/cargo/
-        cargo install cargo-raze --version 0.9.2
-        cargo raze --output=bazel/cargo
+        bazelisk --noworkspace_rc run @cargo_raze//:raze -- --manifest-path=$(pwd)/Cargo.toml
         mv Cargo.lock bazel/cargo/Cargo.raze.lock
         git diff --exit-code
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,6 @@ opt-level = 3
 panic = "abort"
 
 [package.metadata.raze]
-rust_rules_workspace_name = "rules_rust"
 package_aliases_dir = "bazel/cargo"
 workspace_path = "//bazel/cargo"
 genmode = "Remote"

--- a/README.md
+++ b/README.md
@@ -30,6 +30,6 @@
 
 When updating dependencies, you need to regenerate Bazel `BUILD` files to match updated `Cargo.toml`:
 ```
-cargo install cargo-raze --version 0.9.2
-cargo raze --generate-lockfile --output=bazel/cargo
+cargo install cargo-raze --version 0.11.0
+cargo raze --generate-lockfile
 ```

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,10 +4,26 @@ load("@proxy_wasm_rust_sdk//bazel:repositories.bzl", "proxy_wasm_rust_sdk_reposi
 
 proxy_wasm_rust_sdk_repositories()
 
-load("@proxy_wasm_rust_sdk//bazel:dependencies.bzl", "proxy_wasm_rust_sdk_cargo_raze_dependencies", "proxy_wasm_rust_sdk_dependencies")
+load("@proxy_wasm_rust_sdk//bazel:dependencies.bzl", "proxy_wasm_rust_sdk_dependencies")
 
 proxy_wasm_rust_sdk_dependencies()
 
 # Needed only when using @cargo_raze//:raze to generate BUILD files in //bazel/cargo.
 
-proxy_wasm_rust_sdk_cargo_raze_dependencies()
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "cargo_raze",
+    sha256 = "73c5cea8ad3f4ef7788116d491070eeb27819fe0f923dbb6f451f69dd5fa752c",
+    # v0.11.0 with a few Bazel fixes.
+    strip_prefix = "cargo-raze-7614085d2748e55ad3032c9b1dca78f6011cb40e",
+    url = "https://github.com/google/cargo-raze/archive/7614085d2748e55ad3032c9b1dca78f6011cb40e.tar.gz",
+)
+
+load("@cargo_raze//:repositories.bzl", "cargo_raze_repositories")
+
+cargo_raze_repositories()
+
+load("@cargo_raze//:transitive_deps.bzl", "cargo_raze_transitive_deps")
+
+cargo_raze_transitive_deps()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,6 +4,10 @@ load("@proxy_wasm_rust_sdk//bazel:repositories.bzl", "proxy_wasm_rust_sdk_reposi
 
 proxy_wasm_rust_sdk_repositories()
 
-load("@proxy_wasm_rust_sdk//bazel:dependencies.bzl", "proxy_wasm_rust_sdk_dependencies")
+load("@proxy_wasm_rust_sdk//bazel:dependencies.bzl", "proxy_wasm_rust_sdk_cargo_raze_dependencies", "proxy_wasm_rust_sdk_dependencies")
 
 proxy_wasm_rust_sdk_dependencies()
+
+# Needed only when using @cargo_raze//:raze to generate BUILD files in //bazel/cargo.
+
+proxy_wasm_rust_sdk_cargo_raze_dependencies()

--- a/bazel/cargo/remote/BUILD.ahash-0.4.7.bazel
+++ b/bazel/cargo/remote/BUILD.ahash-0.4.7.bazel
@@ -6,15 +6,15 @@ DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
 # buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
     "rust_binary",
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/bazel/cargo/remote/BUILD.autocfg-1.0.1.bazel
+++ b/bazel/cargo/remote/BUILD.autocfg-1.0.1.bazel
@@ -6,15 +6,15 @@ DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
 # buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
     "rust_binary",
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/bazel/cargo/remote/BUILD.cfg-if-1.0.0.bazel
+++ b/bazel/cargo/remote/BUILD.cfg-if-1.0.0.bazel
@@ -6,15 +6,15 @@ DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
 # buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
     "rust_binary",
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/bazel/cargo/remote/BUILD.chrono-0.4.19.bazel
+++ b/bazel/cargo/remote/BUILD.chrono-0.4.19.bazel
@@ -6,15 +6,15 @@ DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
 # buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
     "rust_binary",
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/bazel/cargo/remote/BUILD.getrandom-0.2.2.bazel
+++ b/bazel/cargo/remote/BUILD.getrandom-0.2.2.bazel
@@ -6,15 +6,15 @@ DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
 # buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
     "rust_binary",
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
@@ -29,6 +29,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/bazel/cargo/remote/BUILD.hashbrown-0.9.1.bazel
+++ b/bazel/cargo/remote/BUILD.hashbrown-0.9.1.bazel
@@ -6,15 +6,15 @@ DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
 # buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
     "rust_binary",
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/bazel/cargo/remote/BUILD.libc-0.2.88.bazel
+++ b/bazel/cargo/remote/BUILD.libc-0.2.88.bazel
@@ -6,15 +6,15 @@ DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
 # buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
     "rust_binary",
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
@@ -29,6 +29,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/bazel/cargo/remote/BUILD.log-0.4.14.bazel
+++ b/bazel/cargo/remote/BUILD.log-0.4.14.bazel
@@ -6,15 +6,15 @@ DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
 # buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
     "rust_binary",
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
@@ -29,6 +29,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/bazel/cargo/remote/BUILD.num-integer-0.1.44.bazel
+++ b/bazel/cargo/remote/BUILD.num-integer-0.1.44.bazel
@@ -6,15 +6,15 @@ DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
 # buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
     "rust_binary",
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
@@ -29,6 +29,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/bazel/cargo/remote/BUILD.num-traits-0.2.14.bazel
+++ b/bazel/cargo/remote/BUILD.num-traits-0.2.14.bazel
@@ -6,15 +6,15 @@ DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
 # buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
     "rust_binary",
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
@@ -29,6 +29,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/bazel/cargo/remote/BUILD.time-0.1.43.bazel
+++ b/bazel/cargo/remote/BUILD.time-0.1.43.bazel
@@ -6,15 +6,15 @@ DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
 # buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
     "rust_binary",
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/bazel/cargo/remote/BUILD.wasi-0.10.2+wasi-snapshot-preview1.bazel
+++ b/bazel/cargo/remote/BUILD.wasi-0.10.2+wasi-snapshot-preview1.bazel
@@ -6,15 +6,15 @@ DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
 # buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
     "rust_binary",
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.

--- a/bazel/cargo/remote/BUILD.winapi-0.3.9.bazel
+++ b/bazel/cargo/remote/BUILD.winapi-0.3.9.bazel
@@ -6,15 +6,15 @@ DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
 # buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
     "rust_binary",
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
@@ -29,6 +29,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/bazel/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
+++ b/bazel/cargo/remote/BUILD.winapi-i686-pc-windows-gnu-0.4.0.bazel
@@ -6,15 +6,15 @@ DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
 # buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
     "rust_binary",
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
@@ -29,6 +29,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/bazel/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
+++ b/bazel/cargo/remote/BUILD.winapi-x86_64-pc-windows-gnu-0.4.0.bazel
@@ -6,15 +6,15 @@ DO NOT EDIT! Replaced on runs of cargo-raze
 """
 
 # buildifier: disable=load
+load("@bazel_skylib//lib:selects.bzl", "selects")
+
+# buildifier: disable=load
 load(
     "@rules_rust//rust:rust.bzl",
     "rust_binary",
     "rust_library",
     "rust_test",
 )
-
-# buildifier: disable=load
-load("@bazel_skylib//lib:selects.bzl", "selects")
 
 package(default_visibility = [
     # Public for visibility by "@raze__crate__version//" targets.
@@ -29,6 +29,7 @@ licenses([
 ])
 
 # Generated Targets
+# buildifier: disable=out-of-order-load
 # buildifier: disable=load-on-top
 load(
     "@rules_rust//cargo:cargo_build_script.bzl",

--- a/bazel/dependencies.bzl
+++ b/bazel/dependencies.bzl
@@ -12,17 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@cargo_raze//:repositories.bzl", "cargo_raze_repositories")
-load("@cargo_raze//:transitive_deps.bzl", "cargo_raze_transitive_deps")
 load("@proxy_wasm_rust_sdk//bazel/cargo:crates.bzl", "raze_fetch_remote_crates")
-load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
 load("@rules_rust//rust:repositories.bzl", "rust_repositories")
 
 def proxy_wasm_rust_sdk_dependencies():
     rust_repositories()
     raze_fetch_remote_crates()
-
-def proxy_wasm_rust_sdk_cargo_raze_dependencies():
-    rules_foreign_cc_dependencies()
-    cargo_raze_repositories()
-    cargo_raze_transitive_deps()

--- a/bazel/dependencies.bzl
+++ b/bazel/dependencies.bzl
@@ -12,9 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@cargo_raze//:repositories.bzl", "cargo_raze_repositories")
+load("@cargo_raze//:transitive_deps.bzl", "cargo_raze_transitive_deps")
 load("@proxy_wasm_rust_sdk//bazel/cargo:crates.bzl", "raze_fetch_remote_crates")
+load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
 load("@rules_rust//rust:repositories.bzl", "rust_repositories")
 
 def proxy_wasm_rust_sdk_dependencies():
     rust_repositories()
     raze_fetch_remote_crates()
+
+def proxy_wasm_rust_sdk_cargo_raze_dependencies():
+    rules_foreign_cc_dependencies()
+    cargo_raze_repositories()
+    cargo_raze_transitive_deps()

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -13,9 +13,27 @@
 # limitations under the License.
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
 def proxy_wasm_rust_sdk_repositories():
-    http_archive(
+    maybe(
+        http_archive,
+        name = "cargo_raze",
+        sha256 = "c664e258ea79e7e4ec2f2b57bca8b1c37f11c8d5748e02b8224810da969eb681",
+        strip_prefix = "cargo-raze-0.11.0",
+        url = "https://github.com/google/cargo-raze/archive/v0.11.0.tar.gz",
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_foreign_cc",
+        sha256 = "c2cdcf55ffaf49366725639e45dedd449b8c3fe22b54e31625eb80ce3a240f1e",
+        strip_prefix = "rules_foreign_cc-0.1.0",
+        url = "https://github.com/bazelbuild/rules_foreign_cc/archive/0.1.0.zip",
+    )
+
+    maybe(
+        http_archive,
         name = "rules_rust",
         sha256 = "f2d9f804e1a8042a41ad41e1aeeca55ad0fc2d294ecd52e34ef8c63f7ce350fd",
         strip_prefix = "rules_rust-3b02397bde43b1eeee1528227ceb3da6c6bdadd6",

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -18,22 +18,6 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 def proxy_wasm_rust_sdk_repositories():
     maybe(
         http_archive,
-        name = "cargo_raze",
-        sha256 = "c664e258ea79e7e4ec2f2b57bca8b1c37f11c8d5748e02b8224810da969eb681",
-        strip_prefix = "cargo-raze-0.11.0",
-        url = "https://github.com/google/cargo-raze/archive/v0.11.0.tar.gz",
-    )
-
-    maybe(
-        http_archive,
-        name = "rules_foreign_cc",
-        sha256 = "c2cdcf55ffaf49366725639e45dedd449b8c3fe22b54e31625eb80ce3a240f1e",
-        strip_prefix = "rules_foreign_cc-0.1.0",
-        url = "https://github.com/bazelbuild/rules_foreign_cc/archive/0.1.0.zip",
-    )
-
-    maybe(
-        http_archive,
         name = "rules_rust",
         sha256 = "f2d9f804e1a8042a41ad41e1aeeca55ad0fc2d294ecd52e34ef8c63f7ce350fd",
         strip_prefix = "rules_rust-3b02397bde43b1eeee1528227ceb3da6c6bdadd6",


### PR DESCRIPTION
While there, add support for generating BUILD files
with Bazel using @cargo_raze//:raze.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>