### PR TITLE
Add support for gRPC streams.

### DIFF
--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -672,7 +672,7 @@ pub extern "C" fn proxy_on_grpc_receive(_context_id: u32, token_id: u32, respons
 }
 
 #[no_mangle]
-pub extern "C" fn proxy_on_receive_grpc_trailing_metadata(
+pub extern "C" fn proxy_on_grpc_receive_trailing_metadata(
     _context_id: u32,
     token_id: u32,
     trailers: u32,

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -417,12 +417,11 @@ impl Dispatcher {
     }
 
     fn on_grpc_receive_initial_metadata(&self, token_id: u32, headers: u32) {
-        let context_id = self
+        let context_id = *self
             .grpc_streams
             .borrow_mut()
             .get(&token_id)
-            .expect("invalid token_id")
-            .clone();
+            .expect("invalid token_id");
 
         if let Some(http_stream) = self.http_streams.borrow_mut().get_mut(&context_id) {
             self.active_id.set(context_id);
@@ -455,7 +454,7 @@ impl Dispatcher {
                 root.on_grpc_call_response(token_id, 0, response_size);
             }
         } else if let Some(context_id) = self.grpc_streams.borrow_mut().get(&token_id) {
-            let context_id = context_id.clone();
+            let context_id = *context_id;
             if let Some(http_stream) = self.http_streams.borrow_mut().get_mut(&context_id) {
                 self.active_id.set(context_id);
                 hostcalls::set_effective_context(context_id).unwrap();
@@ -475,12 +474,11 @@ impl Dispatcher {
     }
 
     fn on_grpc_receive_trailing_metadata(&self, token_id: u32, trailers: u32) {
-        let context_id = self
+        let context_id = *self
             .grpc_streams
             .borrow_mut()
             .get(&token_id)
-            .expect("invalid token_id")
-            .clone();
+            .expect("invalid token_id");
 
         if let Some(http_stream) = self.http_streams.borrow_mut().get_mut(&context_id) {
             self.active_id.set(context_id);

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -672,7 +672,11 @@ pub extern "C" fn proxy_on_grpc_receive(_context_id: u32, token_id: u32, respons
 }
 
 #[no_mangle]
-pub extern "C" fn proxy_receive_on_grpc_trailing_metadata(_context_id: u32, token_id: u32, trailers: u32) {
+pub extern "C" fn proxy_on_receive_grpc_trailing_metadata(
+    _context_id: u32,
+    token_id: u32,
+    trailers: u32,
+) {
     DISPATCHER.with(|dispatcher| dispatcher.on_grpc_receive_trailing_metadata(token_id, trailers))
 }
 

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -61,7 +61,7 @@ struct Dispatcher {
     active_id: Cell<u32>,
     callouts: RefCell<HashMap<u32, u32>>,
     grpc_callouts: RefCell<HashMap<u32, u32>>,
-    grpc_stream_tokens: RefCell<HashMap<u32, u32>>,
+    grpc_streams: RefCell<HashMap<u32, u32>>,
 }
 
 impl Dispatcher {
@@ -76,7 +76,7 @@ impl Dispatcher {
             active_id: Cell::new(0),
             callouts: RefCell::new(HashMap::new()),
             grpc_callouts: RefCell::new(HashMap::new()),
-            grpc_stream_tokens: RefCell::new(HashMap::new()),
+            grpc_streams: RefCell::new(HashMap::new()),
         }
     }
 
@@ -103,9 +103,9 @@ impl Dispatcher {
         }
     }
 
-    fn register_grpc_stream_tokens(&self, token_id: u32) {
+    fn register_grpc_stream(&self, token_id: u32) {
         if self
-            .grpc_stream_tokens
+            .grpc_streams
             .borrow_mut()
             .insert(token_id, self.active_id.get())
             .is_some()
@@ -416,6 +416,29 @@ impl Dispatcher {
         }
     }
 
+    fn on_grpc_receive_initial_metadata(&self, token_id: u32, headers: u32) {
+        let context_id = self
+            .grpc_streams
+            .borrow_mut()
+            .get(&token_id)
+            .expect("invalid token_id")
+            .clone();
+
+        if let Some(http_stream) = self.http_streams.borrow_mut().get_mut(&context_id) {
+            self.active_id.set(context_id);
+            hostcalls::set_effective_context(context_id).unwrap();
+            http_stream.on_grpc_stream_initial_metadata(token_id, headers);
+        } else if let Some(stream) = self.streams.borrow_mut().get_mut(&context_id) {
+            self.active_id.set(context_id);
+            hostcalls::set_effective_context(context_id).unwrap();
+            stream.on_grpc_stream_initial_metadata(token_id, headers);
+        } else if let Some(root) = self.roots.borrow_mut().get_mut(&context_id) {
+            self.active_id.set(context_id);
+            hostcalls::set_effective_context(context_id).unwrap();
+            root.on_grpc_stream_initial_metadata(token_id, headers);
+        }
+    }
+
     fn on_grpc_receive(&self, token_id: u32, response_size: usize) {
         if let Some(context_id) = self.grpc_callouts.borrow_mut().remove(&token_id) {
             if let Some(http_stream) = self.http_streams.borrow_mut().get_mut(&context_id) {
@@ -431,23 +454,46 @@ impl Dispatcher {
                 hostcalls::set_effective_context(context_id).unwrap();
                 root.on_grpc_call_response(token_id, 0, response_size);
             }
-        } else if let Some(context_id) = self.grpc_callouts.borrow_mut().get(&token_id) {
+        } else if let Some(context_id) = self.grpc_streams.borrow_mut().get(&token_id) {
             let context_id = context_id.clone();
             if let Some(http_stream) = self.http_streams.borrow_mut().get_mut(&context_id) {
                 self.active_id.set(context_id);
                 hostcalls::set_effective_context(context_id).unwrap();
-                http_stream.on_grpc_stream_receive_body(token_id, response_size);
+                http_stream.on_grpc_stream_message(token_id, response_size);
             } else if let Some(stream) = self.streams.borrow_mut().get_mut(&context_id) {
                 self.active_id.set(context_id);
                 hostcalls::set_effective_context(context_id).unwrap();
-                stream.on_grpc_stream_receive_body(token_id, response_size);
+                stream.on_grpc_stream_message(token_id, response_size);
             } else if let Some(root) = self.roots.borrow_mut().get_mut(&context_id) {
                 self.active_id.set(context_id);
                 hostcalls::set_effective_context(context_id).unwrap();
-                root.on_grpc_stream_receive_body(token_id, response_size);
+                root.on_grpc_stream_message(token_id, response_size);
             }
         } else {
             panic!("invalid token_id")
+        }
+    }
+
+    fn on_grpc_receive_trailing_metadata(&self, token_id: u32, trailers: u32) {
+        let context_id = self
+            .grpc_streams
+            .borrow_mut()
+            .get(&token_id)
+            .expect("invalid token_id")
+            .clone();
+
+        if let Some(http_stream) = self.http_streams.borrow_mut().get_mut(&context_id) {
+            self.active_id.set(context_id);
+            hostcalls::set_effective_context(context_id).unwrap();
+            http_stream.on_grpc_stream_initial_metadata(token_id, trailers);
+        } else if let Some(stream) = self.streams.borrow_mut().get_mut(&context_id) {
+            self.active_id.set(context_id);
+            hostcalls::set_effective_context(context_id).unwrap();
+            stream.on_grpc_stream_initial_metadata(token_id, trailers);
+        } else if let Some(root) = self.roots.borrow_mut().get_mut(&context_id) {
+            self.active_id.set(context_id);
+            hostcalls::set_effective_context(context_id).unwrap();
+            root.on_grpc_stream_initial_metadata(token_id, trailers);
         }
     }
 
@@ -466,7 +512,7 @@ impl Dispatcher {
                 hostcalls::set_effective_context(context_id).unwrap();
                 root.on_grpc_call_response(token_id, status_code, 0);
             }
-        } else if let Some(context_id) = self.grpc_stream_tokens.borrow_mut().remove(&token_id) {
+        } else if let Some(context_id) = self.grpc_streams.borrow_mut().remove(&token_id) {
             if let Some(http_stream) = self.http_streams.borrow_mut().get_mut(&context_id) {
                 self.active_id.set(context_id);
                 hostcalls::set_effective_context(context_id).unwrap();
@@ -482,52 +528,6 @@ impl Dispatcher {
             }
         } else {
             panic!("invalid token_id")
-        }
-    }
-
-    fn on_grpc_receive_initial_metadata(&self, token_id: u32, headers: u32) {
-        let context_id = self
-            .grpc_stream_tokens
-            .borrow_mut()
-            .get(&token_id)
-            .expect("invalid token_id")
-            .clone();
-
-        if let Some(http_stream) = self.http_streams.borrow_mut().get_mut(&context_id) {
-            self.active_id.set(context_id);
-            hostcalls::set_effective_context(context_id).unwrap();
-            http_stream.on_grpc_stream_receive_initial_metadata(token_id, headers);
-        } else if let Some(stream) = self.streams.borrow_mut().get_mut(&context_id) {
-            self.active_id.set(context_id);
-            hostcalls::set_effective_context(context_id).unwrap();
-            stream.on_grpc_stream_receive_initial_metadata(token_id, headers);
-        } else if let Some(root) = self.roots.borrow_mut().get_mut(&context_id) {
-            self.active_id.set(context_id);
-            hostcalls::set_effective_context(context_id).unwrap();
-            root.on_grpc_stream_receive_initial_metadata(token_id, headers);
-        }
-    }
-
-    fn on_grpc_receive_trailing_metadata(&self, token_id: u32, trailers: u32) {
-        let context_id = self
-            .grpc_stream_tokens
-            .borrow_mut()
-            .get(&token_id)
-            .expect("invalid token_id")
-            .clone();
-
-        if let Some(http_stream) = self.http_streams.borrow_mut().get_mut(&context_id) {
-            self.active_id.set(context_id);
-            hostcalls::set_effective_context(context_id).unwrap();
-            http_stream.on_grpc_stream_receive_trailing_metadata(token_id, trailers);
-        } else if let Some(stream) = self.streams.borrow_mut().get_mut(&context_id) {
-            self.active_id.set(context_id);
-            hostcalls::set_effective_context(context_id).unwrap();
-            stream.on_grpc_stream_receive_trailing_metadata(token_id, trailers);
-        } else if let Some(root) = self.roots.borrow_mut().get_mut(&context_id) {
-            self.active_id.set(context_id);
-            hostcalls::set_effective_context(context_id).unwrap();
-            root.on_grpc_stream_receive_trailing_metadata(token_id, trailers);
         }
     }
 }
@@ -660,8 +660,22 @@ pub extern "C" fn proxy_on_http_call_response(
 }
 
 #[no_mangle]
+pub extern "C" fn proxy_on_grpc_receive_initial_metadata(
+    _context_id: u32,
+    token_id: u32,
+    headers: u32,
+) {
+    DISPATCHER.with(|dispatcher| dispatcher.on_grpc_receive_initial_metadata(token_id, headers))
+}
+
+#[no_mangle]
 pub extern "C" fn proxy_on_grpc_receive(_context_id: u32, token_id: u32, response_size: usize) {
     DISPATCHER.with(|dispatcher| dispatcher.on_grpc_receive(token_id, response_size))
+}
+
+#[no_mangle]
+pub extern "C" fn proxy_on_grpc_trailing_metadata(_context_id: u32, token_id: u32, trailers: u32) {
+    DISPATCHER.with(|dispatcher| dispatcher.on_grpc_receive_trailing_metadata(token_id, trailers))
 }
 
 #[no_mangle]

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -483,15 +483,15 @@ impl Dispatcher {
         if let Some(http_stream) = self.http_streams.borrow_mut().get_mut(&context_id) {
             self.active_id.set(context_id);
             hostcalls::set_effective_context(context_id).unwrap();
-            http_stream.on_grpc_stream_initial_metadata(token_id, trailers);
+            http_stream.on_grpc_stream_trailing_metadata(token_id, trailers);
         } else if let Some(stream) = self.streams.borrow_mut().get_mut(&context_id) {
             self.active_id.set(context_id);
             hostcalls::set_effective_context(context_id).unwrap();
-            stream.on_grpc_stream_initial_metadata(token_id, trailers);
+            stream.on_grpc_stream_trailing_metadata(token_id, trailers);
         } else if let Some(root) = self.roots.borrow_mut().get_mut(&context_id) {
             self.active_id.set(context_id);
             hostcalls::set_effective_context(context_id).unwrap();
-            root.on_grpc_stream_initial_metadata(token_id, trailers);
+            root.on_grpc_stream_trailing_metadata(token_id, trailers);
         }
     }
 
@@ -672,7 +672,7 @@ pub extern "C" fn proxy_on_grpc_receive(_context_id: u32, token_id: u32, respons
 }
 
 #[no_mangle]
-pub extern "C" fn proxy_on_grpc_trailing_metadata(_context_id: u32, token_id: u32, trailers: u32) {
+pub extern "C" fn proxy_receive_on_grpc_trailing_metadata(_context_id: u32, token_id: u32, trailers: u32) {
     DISPATCHER.with(|dispatcher| dispatcher.on_grpc_receive_trailing_metadata(token_id, trailers))
 }
 

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -119,44 +119,48 @@ pub trait Context {
         hostcalls::cancel_grpc_call(token_id)
     }
 
-    fn create_grpc_stream(
+    fn open_grpc_stream(
         &self,
         cluster_name: &str,
         service_name: &str,
         method_name: &str,
         initial_metadata: Vec<(&str, &[u8])>,
     ) -> Result<u32, Status> {
-        hostcalls::create_grpc_stream(cluster_name, service_name, method_name, initial_metadata)
+        hostcalls::open_grpc_stream(cluster_name, service_name, method_name, initial_metadata)
     }
 
-    fn grpc_stream_send(
+    fn on_grpc_stream_initial_metadata(&mut self, _token_id: u32, _num_elements: u32) {}
+
+    fn get_grpc_stream_initial_metadata(&self) -> Vec<(String, Vec<u8>)> {
+        hostcalls::get_map_bytes(MapType::GrpcReceiveInitialMetadata).unwrap()
+    }
+
+    fn send_grpc_stream_message(
         &self,
         token_id: u32,
         message: Option<&[u8]>,
         end_stream: bool,
     ) -> Result<(), Status> {
-        hostcalls::grpc_stream_send(token_id, message, end_stream)
+        hostcalls::send_grpc_stream_message(token_id, message, end_stream)
     }
 
-    fn grpc_stream_close(&self, token_id: u32) -> Result<(), Status> {
-        hostcalls::grpc_stream_close(token_id)
+    fn on_grpc_stream_message(&mut self, _token_id: u32, _message_size: usize) {}
+
+    fn get_grpc_stream_message(&mut self, start: usize, max_size: usize) -> Option<Bytes> {
+        hostcalls::get_buffer(BufferType::GrpcReceiveBuffer, start, max_size).unwrap()
     }
 
-    fn on_grpc_stream_receive_initial_metadata(&mut self, _token_id: u32, _headers: u32) {}
+    fn on_grpc_stream_trailing_metadata(&mut self, _token_id: u32, _num_elements: u32) {}
 
-    fn on_grpc_stream_receive_trailing_metadata(&mut self, _token_id: u32, _trailers: u32) {}
-
-    fn on_grpc_stream_receive_body(&mut self, _token_id: u32, _response_size: usize) {}
-
-    fn on_grpc_stream_close(&mut self, _token_id: u32, _status_code: u32) {}
-
-    fn get_grpc_call_initial_metadata(&self) -> Vec<(String, Vec<u8>)> {
-        hostcalls::get_map_bytes(MapType::GrpcReceiveInitialMetadata).unwrap()
-    }
-
-    fn get_grpc_call_trailing_metadata(&self) -> Vec<(String, Vec<u8>)> {
+    fn get_grpc_stream_trailing_metadata(&self) -> Vec<(String, Vec<u8>)> {
         hostcalls::get_map_bytes(MapType::GrpcReceiveTrailingMetadata).unwrap()
     }
+
+    fn close_grpc_stream(&self, token_id: u32) -> Result<(), Status> {
+        hostcalls::close_grpc_stream(token_id)
+    }
+
+    fn on_grpc_stream_close(&mut self, _token_id: u32, _status_code: u32) {}
 
     fn on_done(&mut self) -> bool {
         true

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -90,6 +90,36 @@ pub trait Context {
         hostcalls::get_map(MapType::HttpCallResponseTrailers).unwrap()
     }
 
+    fn create_grpc_stream(
+        &self,
+        cluster_name: &str,
+        service_name: &str,
+        method_name: &str,
+        initial_metadata: &str,
+    ) -> Result<u32, Status> {
+        hostcalls::create_grpc_stream(cluster_name, service_name, method_name, initial_metadata)
+    }
+
+    fn grpc_send(&self, token_id: u32, message: &str, end_stream: bool) -> Result<(), Status> {
+        hostcalls::grpc_send(token_id, message, end_stream)
+    }
+
+    fn grpc_cancel(&self, token_id: u32) -> Result<(), Status> {
+        hostcalls::grpc_cancel(token_id)
+    }
+
+    fn grpc_close(&self, token_id: u32) -> Result<(), Status> {
+        hostcalls::grpc_close(token_id)
+    }
+
+    fn on_grpc_receive_initial_metadata(&mut self, _token_id: u32, _headers: u32) {}
+
+    fn on_grpc_receive_trailing_metadata(&mut self, _token_id: u32, _trailers: u32) {}
+
+    fn on_grpc_receive(&mut self, _token_id: u32, _response_size: usize) {}
+
+    fn on_grpc_close(&mut self, _token_id: u32, _status_code: u32) {}
+
     fn on_done(&mut self) -> bool {
         true
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -42,6 +42,7 @@ pub enum Status {
     Ok = 0,
     NotFound = 1,
     BadArgument = 2,
+    ParseFailure = 4,
     Empty = 7,
     CasMismatch = 8,
     InternalFailure = 10,


### PR DESCRIPTION
Add gRPC stream support for Rust SDK. It includes any workaround around callout token table caused by #100 is not landed to master.