### PR TITLE
Use actions/setup-go@v2 in GitHub Actions.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,10 +34,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '^1.16'
 
     - name: Check licenses
       run: |
-        go get -u github.com/google/addlicense
+        go install github.com/google/addlicense@latest
         export PATH=$PATH:$(go env GOPATH)/bin
         addlicense -check .
 
@@ -46,6 +49,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '^1.16'
 
     - name: Cache
       uses: actions/cache@v2
@@ -67,7 +73,7 @@ jobs:
 
     - name: Format (buildifier)
       run: |
-        GO111MODULE=on go get -u github.com/bazelbuild/buildtools/buildifier@3.4.0
+        go install github.com/bazelbuild/buildtools/buildifier@latest
         export PATH=$PATH:$(go env GOPATH)/bin
         buildifier -mode=check WORKSPACE
         buildifier -mode=check BUILD


### PR DESCRIPTION
Fixes issues with addlicense requiring Go v1.16+.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>