### PR TITLE
Update rules_rust to latest (with Rust v1.58.1).

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -3,7 +3,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library")
 rust_library(
     name = "proxy_wasm",
     srcs = glob(["src/*.rs"]),
-    edition = "2021",
+    edition = "2018",
     visibility = ["//visibility:public"],
     deps = [
         "//bazel/cargo:hashbrown",

--- a/BUILD
+++ b/BUILD
@@ -1,9 +1,9 @@
-load("@rules_rust//rust:rust.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_library")
 
 rust_library(
     name = "proxy_wasm",
     srcs = glob(["src/*.rs"]),
-    edition = "2018",
+    edition = "2021",
     visibility = ["//visibility:public"],
     deps = [
         "//bazel/cargo:hashbrown",

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -19,7 +19,7 @@ def proxy_wasm_rust_sdk_repositories():
     maybe(
         http_archive,
         name = "rules_rust",
-        sha256 = "d54b379559f3fe6ff0cd251be216a5e35acf241451eec8144455482e8f4748f8",
-        strip_prefix = "rules_rust-7e7246f6c48a5d4e69744cd79b9ccb8886966ee2",
-        url = "https://github.com/bazelbuild/rules_rust/archive/7e7246f6c48a5d4e69744cd79b9ccb8886966ee2.tar.gz",
+        sha256 = "6c26af1bb98276917fcf29ea942615ab375cf9d3c52f15c27fdd176ced3ee906",
+        strip_prefix = "rules_rust-b3ddf6f096887b757ab1a661662a95d6b2699fa7",
+        url = "https://github.com/bazelbuild/rules_rust/archive/b3ddf6f096887b757ab1a661662a95d6b2699fa7.tar.gz",
     )

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -1,10 +1,10 @@
-load("@rules_rust//rust:rust.bzl", "rust_binary")
+load("@rules_rust//rust:defs.bzl", "rust_binary")
 
 rust_binary(
     name = "hello_world",
     srcs = ["hello_world.rs"],
     crate_type = "cdylib",
-    edition = "2018",
+    edition = "2021",
     out_binary = True,
     deps = [
         "//:proxy_wasm",
@@ -21,7 +21,7 @@ rust_binary(
     name = "http_auth_random",
     srcs = ["http_auth_random.rs"],
     crate_type = "cdylib",
-    edition = "2018",
+    edition = "2021",
     out_binary = True,
     deps = [
         "//:proxy_wasm",
@@ -33,7 +33,7 @@ rust_binary(
     name = "http_headers",
     srcs = ["http_headers.rs"],
     crate_type = "cdylib",
-    edition = "2018",
+    edition = "2021",
     out_binary = True,
     deps = [
         "//:proxy_wasm",
@@ -45,7 +45,7 @@ rust_binary(
     name = "http_body",
     srcs = ["http_body.rs"],
     crate_type = "cdylib",
-    edition = "2018",
+    edition = "2021",
     out_binary = True,
     deps = [
         "//:proxy_wasm",
@@ -57,7 +57,7 @@ rust_binary(
     name = "http_config",
     srcs = ["http_config.rs"],
     crate_type = "cdylib",
-    edition = "2018",
+    edition = "2021",
     out_binary = True,
     deps = [
         "//:proxy_wasm",

--- a/examples/BUILD
+++ b/examples/BUILD
@@ -4,7 +4,7 @@ rust_binary(
     name = "hello_world",
     srcs = ["hello_world.rs"],
     crate_type = "cdylib",
-    edition = "2021",
+    edition = "2018",
     out_binary = True,
     deps = [
         "//:proxy_wasm",
@@ -21,7 +21,7 @@ rust_binary(
     name = "http_auth_random",
     srcs = ["http_auth_random.rs"],
     crate_type = "cdylib",
-    edition = "2021",
+    edition = "2018",
     out_binary = True,
     deps = [
         "//:proxy_wasm",
@@ -33,7 +33,7 @@ rust_binary(
     name = "http_headers",
     srcs = ["http_headers.rs"],
     crate_type = "cdylib",
-    edition = "2021",
+    edition = "2018",
     out_binary = True,
     deps = [
         "//:proxy_wasm",
@@ -45,7 +45,7 @@ rust_binary(
     name = "http_body",
     srcs = ["http_body.rs"],
     crate_type = "cdylib",
-    edition = "2021",
+    edition = "2018",
     out_binary = True,
     deps = [
         "//:proxy_wasm",
@@ -57,7 +57,7 @@ rust_binary(
     name = "http_config",
     srcs = ["http_config.rs"],
     crate_type = "cdylib",
-    edition = "2021",
+    edition = "2018",
     out_binary = True,
     deps = [
         "//:proxy_wasm",


### PR DESCRIPTION
This will likely require the lockfiles to be regenerated to update `edition` versions, but to prevent conflicts it's better to do this after https://github.com/proxy-wasm/proxy-wasm-rust-sdk/pull/131 has been merged.

Extracted from: #129