### PR TITLE
Don't panic on unknown token_id in on_grpc_close.

### DIFF
--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -16,7 +16,7 @@ use crate::hostcalls;
 use crate::traits::*;
 use crate::types::*;
 use hashbrown::HashMap;
-use log::warn;
+use log::trace;
 use std::cell::{Cell, RefCell};
 
 thread_local! {
@@ -536,7 +536,8 @@ impl Dispatcher {
                 root.on_grpc_stream_close(token_id, status_code)
             }
         } else {
-            warn!("on_grpc_close: invalid token_id, a non-connected stream has closed");
+            //TODO: change back to a panic once underlying issue is fixed.
+            trace!("on_grpc_close: invalid token_id, a non-connected stream has closed");
         }
     }
 }

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -536,7 +536,7 @@ impl Dispatcher {
                 root.on_grpc_stream_close(token_id, status_code)
             }
         } else {
-            //TODO: change back to a panic once underlying issue is fixed.
+            // TODO: change back to a panic once underlying issue is fixed.
             trace!("on_grpc_close: invalid token_id, a non-connected stream has closed");
         }
     }

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -16,6 +16,7 @@ use crate::hostcalls;
 use crate::traits::*;
 use crate::types::*;
 use hashbrown::HashMap;
+use log::warn;
 use std::cell::{Cell, RefCell};
 
 thread_local! {
@@ -535,7 +536,7 @@ impl Dispatcher {
                 root.on_grpc_stream_close(token_id, status_code)
             }
         } else {
-            panic!("invalid token_id")
+            warn!("on_grpc_close: invalid token_id, a non-connected stream has closed");
         }
     }
 }


### PR DESCRIPTION
Fixes #153. 

This PR:
* Logs in `on_grpc_close` when an invalid `token_id` is sent from the host. This happens in Envoy when the initial connection fails.