### PR TITLE
Remove "wee-alloc" feature.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -113,20 +113,10 @@ jobs:
         RUSTFLAGS: -D warnings
       run: cargo build --release --all-targets --target=wasm32-wasi
 
-    - name: Build (wasm32-wasi with wee-alloc)
-      env:
-        RUSTFLAGS: -D warnings
-      run: cargo build --release --all-targets --target=wasm32-wasi --features=wee-alloc
-
     - name: Clippy (wasm32-wasi)
       env:
         RUSTFLAGS: -D warnings
       run: cargo clippy --release --all-targets --target=wasm32-wasi
-
-    - name: Clippy (wasm32-wasi with wee-alloc)
-      env:
-        RUSTFLAGS: -D warnings
-      run: cargo clippy --release --all-targets --target=wasm32-wasi --features=wee-alloc
 
     - name: Format (rustfmt)
       run: cargo fmt -- --check
@@ -168,20 +158,10 @@ jobs:
         RUSTFLAGS: -D warnings
       run: cargo build --release --all-targets --target=wasm32-wasi
 
-    - name: Build (wasm32-wasi with wee-alloc)
-      env:
-        RUSTFLAGS: -D warnings
-      run: cargo build --release --all-targets --target=wasm32-wasi --features=wee-alloc
-
     - name: Clippy (wasm32-wasi)
       env:
         RUSTFLAGS: -D warnings
       run: cargo clippy --release --all-targets --target=wasm32-wasi
-
-    - name: Clippy (wasm32-wasi with wee-alloc)
-      env:
-        RUSTFLAGS: -D warnings
-      run: cargo clippy --release --all-targets --target=wasm32-wasi --features=wee-alloc
 
     - name: Format (rustfmt)
       run: cargo fmt -- --check
@@ -217,20 +197,10 @@ jobs:
         RUSTFLAGS: -D warnings -Z wasi-exec-model=reactor
       run: cargo build --release --all-targets --target=wasm32-wasi
 
-    - name: Build (wasm32-wasi with wee-alloc)
-      env:
-        RUSTFLAGS: -D warnings -Z wasi-exec-model=reactor
-      run: cargo build --release --all-targets --target=wasm32-wasi --features=wee-alloc
-
     - name: Clippy (wasm32-wasi)
       env:
         RUSTFLAGS: -D warnings -Z wasi-exec-model=reactor
       run: cargo clippy --release --all-targets --target=wasm32-wasi
-
-    - name: Clippy (wasm32-wasi with wee-alloc)
-      env:
-        RUSTFLAGS: -D warnings -Z wasi-exec-model=reactor
-      run: cargo clippy --release --all-targets --target=wasm32-wasi --features=wee-alloc
 
   outdated:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Removed
+
+- Removed `wee-alloc` feature, because that crate is no longer maintained
+  and it leaks memory.
+
 ## [0.2.0] - 2022-04-08
 
 ### Fixed
@@ -70,6 +77,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Initial release.
 
 
+[Unreleased]: https://github.com/proxy-wasm/proxy-wasm-rust-sdk/compare/v0.2.0...HEAD
 [0.2.0]: https://github.com/proxy-wasm/proxy-wasm-rust-sdk/compare/v0.1.4...v0.2.0
 [0.1.4]: https://github.com/proxy-wasm/proxy-wasm-rust-sdk/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/proxy-wasm/proxy-wasm-rust-sdk/compare/v0.1.2...v0.1.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,9 @@ repository = "https://github.com/proxy-wasm/proxy-wasm-rust-sdk"
 edition = "2018"
 build = "build.rs"
 
-[features]
-wee-alloc = ["wee_alloc"]
-
 [dependencies]
 hashbrown = "0.12"
 log = "0.4"
-wee_alloc = { version = "0.4", optional = true }
 
 [dev-dependencies]
 cfg-if = "1.0"

--- a/bazel/cargo/Cargo.raze.lock
+++ b/bazel/cargo/Cargo.raze.lock
@@ -19,12 +19,6 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
-name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -47,7 +41,7 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9be70c98951c83b8d2f8f60d7065fa6d5146873094452a1008da8c2f1e4205ad"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi",
 ]
@@ -73,14 +67,8 @@ version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
-
-[[package]]
-name = "memory_units"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
 name = "num-integer"
@@ -111,12 +99,11 @@ checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 name = "proxy-wasm"
 version = "0.2.0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "chrono",
  "getrandom",
  "hashbrown",
  "log",
- "wee_alloc",
 ]
 
 [[package]]
@@ -130,18 +117,6 @@ name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
-
-[[package]]
-name = "wee_alloc"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb3b5a6b2bb17cb6ad44a2e68a43e8d2722c997da10e928665c72ec6c0a0b8e"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "memory_units",
- "winapi",
-]
 
 [[package]]
 name = "winapi"

--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -14,10 +14,6 @@
 
 use std::mem::MaybeUninit;
 
-#[cfg(feature = "wee-alloc")]
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
-
 #[cfg_attr(
     all(target_arch = "wasm32", target_os = "unknown"),
     export_name = "malloc"


### PR DESCRIPTION
The "wee_alloc" crate is no longer maintained and it leaks memory.

Reported in #167.

Signed-off-by: Piotr Sikora <piotr@aviatrix.com>