### PR TITLE
Don't panic on unknown token_id in gRPC callbacks.

### DIFF
--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -491,11 +491,17 @@ impl Dispatcher {
     }
 
     fn on_grpc_receive_trailing_metadata(&self, token_id: u32, trailers: u32) {
-        let context_id = *self
-            .grpc_streams
-            .borrow_mut()
-            .get(&token_id)
-            .expect("invalid token_id");
+        let grpc_streams_ref = self.grpc_streams.borrow_mut();
+        let context_id_hash_slot = grpc_streams_ref
+            .get(&token_id);
+        let context_id = match context_id_hash_slot {
+            Some(id) => *id,
+            None => {
+                // TODO: change back to a panic once underlying issue is fixed.
+                trace!("on_grpc_receive_initial_metadata: invalid token_id");
+                return;
+            }
+        };
 
         if let Some(http_stream) = self.http_streams.borrow_mut().get_mut(&context_id) {
             self.active_id.set(context_id);

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -429,8 +429,7 @@ impl Dispatcher {
 
     fn on_grpc_receive_initial_metadata(&self, token_id: u32, headers: u32) {
         let grpc_streams_ref = self.grpc_streams.borrow_mut();
-        let context_id_hash_slot = grpc_streams_ref
-            .get(&token_id);
+        let context_id_hash_slot = grpc_streams_ref.get(&token_id);
         let context_id = match context_id_hash_slot {
             Some(id) => *id,
             None => {
@@ -492,8 +491,7 @@ impl Dispatcher {
 
     fn on_grpc_receive_trailing_metadata(&self, token_id: u32, trailers: u32) {
         let grpc_streams_ref = self.grpc_streams.borrow_mut();
-        let context_id_hash_slot = grpc_streams_ref
-            .get(&token_id);
+        let context_id_hash_slot = grpc_streams_ref.get(&token_id);
         let context_id = match context_id_hash_slot {
             Some(id) => *id,
             None => {

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -428,11 +428,17 @@ impl Dispatcher {
     }
 
     fn on_grpc_receive_initial_metadata(&self, token_id: u32, headers: u32) {
-        let context_id = *self
-            .grpc_streams
-            .borrow_mut()
-            .get(&token_id)
-            .expect("invalid token_id");
+        let grpc_streams_ref = self.grpc_streams.borrow_mut();
+        let context_id_hash_slot = grpc_streams_ref
+            .get(&token_id);
+        let context_id = match context_id_hash_slot {
+            Some(id) => *id,
+            None => {
+                // TODO: change back to a panic once underlying issue is fixed.
+                trace!("on_grpc_receive_initial_metadata: invalid token_id");
+                return;
+            }
+        };
 
         if let Some(http_stream) = self.http_streams.borrow_mut().get_mut(&context_id) {
             self.active_id.set(context_id);

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -428,9 +428,7 @@ impl Dispatcher {
     }
 
     fn on_grpc_receive_initial_metadata(&self, token_id: u32, headers: u32) {
-        let grpc_streams_ref = self.grpc_streams.borrow_mut();
-        let context_id_hash_slot = grpc_streams_ref.get(&token_id);
-        let context_id = match context_id_hash_slot {
+        let context_id = match self.grpc_streams.borrow_mut().get(&token_id) {
             Some(id) => *id,
             None => {
                 // TODO: change back to a panic once underlying issue is fixed.
@@ -490,9 +488,7 @@ impl Dispatcher {
     }
 
     fn on_grpc_receive_trailing_metadata(&self, token_id: u32, trailers: u32) {
-        let grpc_streams_ref = self.grpc_streams.borrow_mut();
-        let context_id_hash_slot = grpc_streams_ref.get(&token_id);
-        let context_id = match context_id_hash_slot {
+        let context_id = match self.grpc_streams.borrow_mut().get(&token_id) {
             Some(id) => *id,
             None => {
                 // TODO: change back to a panic once underlying issue is fixed.

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -483,7 +483,9 @@ impl Dispatcher {
                 root.on_grpc_stream_message(token_id, response_size);
             }
         } else {
-            panic!("invalid token_id")
+            // TODO: change back to a panic once underlying issue is fixed.
+            trace!("on_grpc_receive_initial_metadata: invalid token_id");
+            return;
         }
     }
 

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -485,7 +485,6 @@ impl Dispatcher {
         } else {
             // TODO: change back to a panic once underlying issue is fixed.
             trace!("on_grpc_receive_initial_metadata: invalid token_id");
-            return;
         }
     }
 

--- a/src/dispatcher.rs
+++ b/src/dispatcher.rs
@@ -496,7 +496,7 @@ impl Dispatcher {
             Some(id) => *id,
             None => {
                 // TODO: change back to a panic once underlying issue is fixed.
-                trace!("on_grpc_receive_initial_metadata: invalid token_id");
+                trace!("on_grpc_receive_trailing_metadata: invalid token_id");
                 return;
             }
         };


### PR DESCRIPTION
Sometimes `Dispatcher.on_grpc_receive_initial_metadata()` will get an invalid stream ID, and then panic. `Dispatcher.on_grpc_receive_trailing_metadata()` as well.

This is a quick fix that will turn a `panic!()` call into a `trace!()` call. The broader issue/bug is out of scope here, though as far as I know it's benign other than this panic.

~NOTE: there may be a more concise way to write this Rust code.~ (thanks Piotr)
NOTE: adding this change to `on_grpc_receive()` as well, just to be safe, even though I haven't seen this panic get triggered myself.

See:
1. Issue with more details: https://github.com/proxy-wasm/proxy-wasm-rust-sdk/issues/206
2. Issue tracking why these two methods get an invalid token number at all: https://github.com/proxy-wasm/proxy-wasm-cpp-host/issues/373