### PR TITLE
Restore Bazel example to verify working rules_rust.

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -45,6 +45,7 @@ rust_binary(
     crate_type = "cdylib",
     edition = "2018",
     out_binary = True,
+    rustc_flags = ["-Cstrip=debuginfo"],
     visibility = ["//visibility:private"],
     deps = [
         ":proxy_wasm",

--- a/BUILD
+++ b/BUILD
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@rules_rust//cargo:cargo_build_script.bzl", "cargo_build_script")
-load("@rules_rust//rust:defs.bzl", "rust_library")
+load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_library")
 
 exports_files([
     "Cargo.toml",
@@ -35,6 +35,19 @@ rust_library(
     deps = [
         ":proxy_wasm_build_script",
         "//bazel/cargo/remote:hashbrown",
+        "//bazel/cargo/remote:log",
+    ],
+)
+
+rust_binary(
+    name = "http_auth_random",
+    srcs = ["examples/http_auth_random/src/lib.rs"],
+    crate_type = "cdylib",
+    edition = "2018",
+    out_binary = True,
+    visibility = ["//visibility:private"],
+    deps = [
+        ":proxy_wasm",
         "//bazel/cargo/remote:log",
     ],
 )


### PR DESCRIPTION
Bazel examples were removed in #146.