### PR TITLE
Accept more Status codes in get_property.

### DIFF
--- a/src/hostcalls.rs
+++ b/src/hostcalls.rs
@@ -416,6 +416,8 @@ pub fn get_property(path: Vec<&str>) -> Result<Option<Bytes>, Status> {
                 }
             }
             Status::NotFound => Ok(None),
+            Status::SerializationFailure => Err(Status::SerializationFailure),
+            Status::InternalFailure => Err(Status::InternalFailure),
             status => panic!("unexpected status: {}", status as u32),
         }
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -46,14 +46,9 @@ pub enum Status {
     BadArgument = 2,
     SerializationFailure = 3,
     ParseFailure = 4,
-    BadExpression = 5,
-    InvalidMemoryAccess = 6,
     Empty = 7,
     CasMismatch = 8,
-    ResultMismatch = 9,
     InternalFailure = 10,
-    BrokenConnection = 11,
-    Unimplemented = 12,
 }
 
 #[repr(u32)]

--- a/src/types.rs
+++ b/src/types.rs
@@ -44,10 +44,16 @@ pub enum Status {
     Ok = 0,
     NotFound = 1,
     BadArgument = 2,
+    SerializationFailure = 3,
     ParseFailure = 4,
+    BadExpression = 5,
+    InvalidMemoryAccess = 6,
     Empty = 7,
     CasMismatch = 8,
+    ResultMismatch = 9,
     InternalFailure = 10,
+    BrokenConnection = 11,
+    Unimplemented = 12,
 }
 
 #[repr(u32)]


### PR DESCRIPTION
Adds the missing `Status` enum variants...
We currently run into `SerializationFailure` when getting some attribute `filter_state` from Envoy... Today, this not only panics, but the error isn't even really recognized. 
I'm not sure, given the current `trait Context` definition how to best deal with these gracefully tho? The default implementation are "just" `Result::unwrap()` ing the underlying host call.. So thinking that [this](https://github.com/proxy-wasm/proxy-wasm-rust-sdk/pull/237/commits/64712b3d50dd0eb45db8de2af6be9e31bfb83ff2) is the best for now, wdyt?