### PR TITLE
Update Envoy to v1.31.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -287,7 +287,7 @@ jobs:
         docker run --rm \
           -v $(pwd)/envoy.yaml:/envoy.yaml \
           -v $(pwd)/target/wasm32-wasi/release:/etc/envoy/proxy-wasm-plugins \
-          envoyproxy/envoy:v1.24-latest \
+          envoyproxy/envoy:v1.31-latest \
           --mode validate \
           -c envoy.yaml
 
@@ -365,6 +365,6 @@ jobs:
         docker run --rm \
           -v $(pwd)/envoy.yaml:/envoy.yaml \
           -v $(pwd)/target/wasm32-wasi/release:/etc/envoy/proxy-wasm-plugins \
-          envoyproxy/envoy:v1.24-latest \
+          envoyproxy/envoy:v1.31-latest \
           --mode validate \
           -c envoy.yaml

--- a/examples/grpc_auth_random/docker-compose.yaml
+++ b/examples/grpc_auth_random/docker-compose.yaml
@@ -14,7 +14,7 @@
 
 services:
   envoy:
-    image: envoyproxy/envoy:v1.24-latest
+    image: envoyproxy/envoy:v1.31-latest
     hostname: envoy
     ports:
       - "10000:10000"

--- a/examples/hello_world/docker-compose.yaml
+++ b/examples/hello_world/docker-compose.yaml
@@ -14,7 +14,7 @@
 
 services:
   envoy:
-    image: envoyproxy/envoy:v1.24-latest
+    image: envoyproxy/envoy:v1.31-latest
     hostname: envoy
     ports:
       - "10000:10000"

--- a/examples/http_auth_random/docker-compose.yaml
+++ b/examples/http_auth_random/docker-compose.yaml
@@ -14,7 +14,7 @@
 
 services:
   envoy:
-    image: envoyproxy/envoy:v1.24-latest
+    image: envoyproxy/envoy:v1.31-latest
     hostname: envoy
     ports:
       - "10000:10000"

--- a/examples/http_body/docker-compose.yaml
+++ b/examples/http_body/docker-compose.yaml
@@ -14,7 +14,7 @@
 
 services:
   envoy:
-    image: envoyproxy/envoy:v1.24-latest
+    image: envoyproxy/envoy:v1.31-latest
     hostname: envoy
     ports:
       - "10000:10000"

--- a/examples/http_config/docker-compose.yaml
+++ b/examples/http_config/docker-compose.yaml
@@ -14,7 +14,7 @@
 
 services:
   envoy:
-    image: envoyproxy/envoy:v1.24-latest
+    image: envoyproxy/envoy:v1.31-latest
     hostname: envoy
     ports:
       - "10000:10000"

--- a/examples/http_headers/docker-compose.yaml
+++ b/examples/http_headers/docker-compose.yaml
@@ -14,7 +14,7 @@
 
 services:
   envoy:
-    image: envoyproxy/envoy:v1.24-latest
+    image: envoyproxy/envoy:v1.31-latest
     hostname: envoy
     ports:
       - "10000:10000"


### PR DESCRIPTION
Notably, it fixes an issue with always injecting invalid "grpc-status"
HTTP response header when sending local HTTP response to gRPC clients.

Fixes #211.