### PR TITLE
Optimize Vec allocations in map deserialization.

### DIFF
--- a/src/hostcalls.rs
+++ b/src/hostcalls.rs
@@ -152,8 +152,8 @@ pub fn get_map(map_type: MapType) -> Result<Vec<(String, String)>, Status> {
         match proxy_get_header_map_pairs(map_type, &mut return_data, &mut return_size) {
             Status::Ok => {
                 if !return_data.is_null() {
-                    let serialized_map = Vec::from_raw_parts(return_data, return_size, return_size);
-                    Ok(utils::deserialize_map(&serialized_map))
+                    let serialized_map = std::slice::from_raw_parts(return_data, return_size);
+                    Ok(utils::deserialize_map(serialized_map))
                 } else {
                     Ok(Vec::new())
                 }
@@ -170,8 +170,8 @@ pub fn get_map_bytes(map_type: MapType) -> Result<Vec<(String, Bytes)>, Status> 
         match proxy_get_header_map_pairs(map_type, &mut return_data, &mut return_size) {
             Status::Ok => {
                 if !return_data.is_null() {
-                    let serialized_map = Vec::from_raw_parts(return_data, return_size, return_size);
-                    Ok(utils::deserialize_map_bytes(&serialized_map))
+                    let serialized_map = std::slice::from_raw_parts(return_data, return_size);
+                    Ok(utils::deserialize_map_bytes(serialized_map))
                 } else {
                     Ok(Vec::new())
                 }
@@ -1200,11 +1200,11 @@ mod utils {
     }
 
     pub(super) fn deserialize_map(bytes: &[u8]) -> Vec<(String, String)> {
-        let mut map = Vec::new();
         if bytes.is_empty() {
-            return map;
+            return Vec::new();
         }
         let size = u32::from_le_bytes(<[u8; 4]>::try_from(&bytes[0..4]).unwrap()) as usize;
+        let mut map = Vec::with_capacity(size);
         let mut p = 4 + size * 8;
         for n in 0..size {
             let s = 4 + n * 8;
@@ -1224,11 +1224,11 @@ mod utils {
     }
 
     pub(super) fn deserialize_map_bytes(bytes: &[u8]) -> Vec<(String, Bytes)> {
-        let mut map = Vec::new();
         if bytes.is_empty() {
-            return map;
+            return Vec::new();
         }
         let size = u32::from_le_bytes(<[u8; 4]>::try_from(&bytes[0..4]).unwrap()) as usize;
+        let mut map = Vec::with_capacity(size);
         let mut p = 4 + size * 8;
         for n in 0..size {
             let s = 4 + n * 8;


### PR DESCRIPTION
Before:

utils::bench_deserialize_map       ... bench:   171.39 ns/iter (+/- 3.53)
utils::bench_deserialize_map_bytes ... bench:   148.27 ns/iter (+/- 3.19)

After:

utils::bench_deserialize_map       ... bench:   168.34 ns/iter (+/- 3.19)
utils::bench_deserialize_map_bytes ... bench:   145.40 ns/iter (+/- 1.92)