### PR TITLE
Update MSRV to Rust v1.65.0.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -125,14 +125,14 @@ jobs:
       run: |
         curl -OL https://static.rust-lang.org/rustup/rustup-init.sh
         chmod +x ./rustup-init.sh
-        ./rustup-init.sh -y --default-toolchain 1.64.0
+        ./rustup-init.sh -y --default-toolchain 1.65.0
         rm rustup-init.sh
         echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
     - name: Update Rust
       run: |
-        rustup toolchain install 1.64.0 --component clippy --component rustfmt
-        rustup default 1.64.0
+        rustup toolchain install 1.65.0 --component clippy --component rustfmt
+        rustup default 1.65.0
         rustup target add wasm32-unknown-unknown
         rustup target add wasm32-wasi
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "proxy-wasm"
 version = "0.2.3-dev"
 authors = ["Piotr Sikora <piotrsikora@google.com>"]
-rust-version = "1.64"
+rust-version = "1.65"
 description = "WebAssembly for Proxies"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Hashbrown updated its MSRV in a patch release (v0.15.1),
so we have to follow.