### PR TITLE
Update hashbrown to v0.15.2.

### DIFF
--- a/bazel/cargo/Cargo.Bazel.lock
+++ b/bazel/cargo/Cargo.Bazel.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.18"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "equivalent"
@@ -16,15 +16,15 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "foldhash"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
  "allocator-api2",
  "equivalent",

--- a/bazel/cargo/remote/BUILD.allocator-api2-0.2.21.bazel
+++ b/bazel/cargo/remote/BUILD.allocator-api2-0.2.21.bazel
@@ -80,5 +80,5 @@ rust_library(
         "@rules_rust//rust/platform:x86_64-unknown-none": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
-    version = "0.2.18",
+    version = "0.2.21",
 )

--- a/bazel/cargo/remote/BUILD.bazel
+++ b/bazel/cargo/remote/BUILD.bazel
@@ -33,7 +33,7 @@ filegroup(
 # Workspace Member Dependencies
 alias(
     name = "hashbrown",
-    actual = "@crates_vendor__hashbrown-0.15.0//:hashbrown",
+    actual = "@crates_vendor__hashbrown-0.15.2//:hashbrown",
     tags = ["manual"],
 )
 

--- a/bazel/cargo/remote/BUILD.foldhash-0.1.4.bazel
+++ b/bazel/cargo/remote/BUILD.foldhash-0.1.4.bazel
@@ -77,5 +77,5 @@ rust_library(
         "@rules_rust//rust/platform:x86_64-unknown-none": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
-    version = "0.1.3",
+    version = "0.1.4",
 )

--- a/bazel/cargo/remote/BUILD.hashbrown-0.15.2.bazel
+++ b/bazel/cargo/remote/BUILD.hashbrown-0.15.2.bazel
@@ -85,10 +85,10 @@ rust_library(
         "@rules_rust//rust/platform:x86_64-unknown-none": [],
         "//conditions:default": ["@platforms//:incompatible"],
     }),
-    version = "0.15.0",
+    version = "0.15.2",
     deps = [
-        "@crates_vendor__allocator-api2-0.2.18//:allocator_api2",
+        "@crates_vendor__allocator-api2-0.2.21//:allocator_api2",
         "@crates_vendor__equivalent-1.0.1//:equivalent",
-        "@crates_vendor__foldhash-0.1.3//:foldhash",
+        "@crates_vendor__foldhash-0.1.4//:foldhash",
     ],
 )

--- a/bazel/cargo/remote/defs.bzl
+++ b/bazel/cargo/remote/defs.bzl
@@ -295,7 +295,7 @@ def aliases(
 _NORMAL_DEPENDENCIES = {
     "": {
         _COMMON_CONDITION: {
-            "hashbrown": Label("@crates_vendor__hashbrown-0.15.0//:hashbrown"),
+            "hashbrown": Label("@crates_vendor__hashbrown-0.15.2//:hashbrown"),
             "log": Label("@crates_vendor__log-0.4.22//:log"),
         },
     },
@@ -405,12 +405,12 @@ def crate_repositories():
     """
     maybe(
         http_archive,
-        name = "crates_vendor__allocator-api2-0.2.18",
-        sha256 = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f",
+        name = "crates_vendor__allocator-api2-0.2.21",
+        sha256 = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923",
         type = "tar.gz",
-        urls = ["https://static.crates.io/crates/allocator-api2/0.2.18/download"],
-        strip_prefix = "allocator-api2-0.2.18",
-        build_file = Label("@proxy_wasm_rust_sdk//bazel/cargo/remote:BUILD.allocator-api2-0.2.18.bazel"),
+        urls = ["https://static.crates.io/crates/allocator-api2/0.2.21/download"],
+        strip_prefix = "allocator-api2-0.2.21",
+        build_file = Label("@proxy_wasm_rust_sdk//bazel/cargo/remote:BUILD.allocator-api2-0.2.21.bazel"),
     )
 
     maybe(
@@ -425,22 +425,22 @@ def crate_repositories():
 
     maybe(
         http_archive,
-        name = "crates_vendor__foldhash-0.1.3",
-        sha256 = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2",
+        name = "crates_vendor__foldhash-0.1.4",
+        sha256 = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f",
         type = "tar.gz",
-        urls = ["https://static.crates.io/crates/foldhash/0.1.3/download"],
-        strip_prefix = "foldhash-0.1.3",
-        build_file = Label("@proxy_wasm_rust_sdk//bazel/cargo/remote:BUILD.foldhash-0.1.3.bazel"),
+        urls = ["https://static.crates.io/crates/foldhash/0.1.4/download"],
+        strip_prefix = "foldhash-0.1.4",
+        build_file = Label("@proxy_wasm_rust_sdk//bazel/cargo/remote:BUILD.foldhash-0.1.4.bazel"),
     )
 
     maybe(
         http_archive,
-        name = "crates_vendor__hashbrown-0.15.0",
-        sha256 = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb",
+        name = "crates_vendor__hashbrown-0.15.2",
+        sha256 = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289",
         type = "tar.gz",
-        urls = ["https://static.crates.io/crates/hashbrown/0.15.0/download"],
-        strip_prefix = "hashbrown-0.15.0",
-        build_file = Label("@proxy_wasm_rust_sdk//bazel/cargo/remote:BUILD.hashbrown-0.15.0.bazel"),
+        urls = ["https://static.crates.io/crates/hashbrown/0.15.2/download"],
+        strip_prefix = "hashbrown-0.15.2",
+        build_file = Label("@proxy_wasm_rust_sdk//bazel/cargo/remote:BUILD.hashbrown-0.15.2.bazel"),
     )
 
     maybe(
@@ -454,6 +454,6 @@ def crate_repositories():
     )
 
     return [
-        struct(repo = "crates_vendor__hashbrown-0.15.0", is_dev_dep = False),
+        struct(repo = "crates_vendor__hashbrown-0.15.2", is_dev_dep = False),
         struct(repo = "crates_vendor__log-0.4.22", is_dev_dep = False),
     ]


### PR DESCRIPTION
The RUSTSEC-2024-0402 advisory was published for a feature of hashbrown
that we don't use, but we need to update its version in the lockfile to
silence the warning.