### PR TITLE
Fix conditional attributes in exported allocator name.

### DIFF
--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -18,7 +18,7 @@ use std::mem::MaybeUninit;
     all(target_arch = "wasm32", target_os = "unknown"),
     export_name = "malloc"
 )]
-#[no_mangle]
+#[cfg_attr(not(all(target_arch = "wasm32", target_os = "unknown")), no_mangle)]
 pub extern "C" fn proxy_on_memory_allocate(size: usize) -> *mut u8 {
     let mut vec: Vec<MaybeUninit<u8>> = Vec::with_capacity(size);
     unsafe {


### PR DESCRIPTION
`#[export_name]` already takes precedence over `#[no_mangle]`,
so this is a no-op, but it silences the warning.

Found with nightly.