### PR TITLE
Differentiate between missing and empty headers.

### DIFF
--- a/src/hostcalls.rs
+++ b/src/hostcalls.rs
@@ -241,7 +241,7 @@ pub fn get_map_value(map_type: MapType, key: &str) -> Result<Option<String>, Sta
                         .unwrap(),
                     ))
                 } else {
-                    Ok(None)
+                    Ok(Some(String::new()))
                 }
             }
             Status::NotFound => Ok(None),
@@ -269,7 +269,7 @@ pub fn get_map_value_bytes(map_type: MapType, key: &str) -> Result<Option<Bytes>
                         return_size,
                     )))
                 } else {
-                    Ok(None)
+                    Ok(Some(Vec::new()))
                 }
             }
             Status::NotFound => Ok(None),


### PR DESCRIPTION
The method `get_http_request_headers_bytes` return empty vector for empty header value but `get_http_request_header_bytes` returns None for empty header value.   

Similarly `get_http_request_headers` returns empty String but `get_http_request_header` returns None.

This commit intends to fix this inconsistency.

With this, it will be possible to differentiate between two cases, a missing header and a header with empty value.