### PR TITLE
Fix formatting in Envoy metadata example.

### DIFF
--- a/examples/envoy_filter_metadata/src/lib.rs
+++ b/examples/envoy_filter_metadata/src/lib.rs
@@ -38,9 +38,7 @@ impl HttpContext for MetadataHttp {
                     self.send_http_response(
                         200,
                         vec![("Powered-By", "proxy-wasm"), ("uppercased-metadata", &data)],
-                        Some(
-                            format!("Custom response with Envoy metadata: {:?}\n", data).as_bytes(),
-                        ),
+                        Some(format!("Custom response with Envoy metadata: {data:?}\n").as_bytes()),
                     );
                     Action::Pause
                 }


### PR DESCRIPTION
Found by clippy (nightly).