### PR TITLE
Ignore clippy's manual_is_multiple_of warning.

### DIFF
--- a/examples/grpc_auth_random/src/lib.rs
+++ b/examples/grpc_auth_random/src/lib.rs
@@ -68,6 +68,7 @@ impl HttpContext for GrpcAuthRandom {
 
 impl Context for GrpcAuthRandom {
     fn on_grpc_call_response(&mut self, _: u32, status_code: u32, _: usize) {
+        #[allow(unknown_lints)]
         #[allow(clippy::manual_is_multiple_of)]
         if status_code % 2 == 0 {
             info!("Access granted.");

--- a/examples/grpc_auth_random/src/lib.rs
+++ b/examples/grpc_auth_random/src/lib.rs
@@ -68,6 +68,7 @@ impl HttpContext for GrpcAuthRandom {
 
 impl Context for GrpcAuthRandom {
     fn on_grpc_call_response(&mut self, _: u32, status_code: u32, _: usize) {
+        #[allow(clippy::manual_is_multiple_of)]
         if status_code % 2 == 0 {
             info!("Access granted.");
             self.resume_http_request();

--- a/examples/grpc_auth_random/src/lib.rs
+++ b/examples/grpc_auth_random/src/lib.rs
@@ -68,8 +68,7 @@ impl HttpContext for GrpcAuthRandom {
 
 impl Context for GrpcAuthRandom {
     fn on_grpc_call_response(&mut self, _: u32, status_code: u32, _: usize) {
-        #[allow(unknown_lints)]
-        #[allow(clippy::manual_is_multiple_of)]
+        #[allow(unknown_lints, clippy::manual_is_multiple_of)]
         if status_code % 2 == 0 {
             info!("Access granted.");
             self.resume_http_request();

--- a/examples/http_auth_random/src/lib.rs
+++ b/examples/http_auth_random/src/lib.rs
@@ -50,6 +50,7 @@ impl HttpContext for HttpAuthRandom {
 impl Context for HttpAuthRandom {
     fn on_http_call_response(&mut self, _: u32, _: usize, body_size: usize, _: usize) {
         if let Some(body) = self.get_http_call_response_body(0, body_size) {
+            #[allow(unknown_lints)]
             #[allow(clippy::manual_is_multiple_of)]
             if !body.is_empty() && body[0] % 2 == 0 {
                 info!("Access granted.");

--- a/examples/http_auth_random/src/lib.rs
+++ b/examples/http_auth_random/src/lib.rs
@@ -50,8 +50,7 @@ impl HttpContext for HttpAuthRandom {
 impl Context for HttpAuthRandom {
     fn on_http_call_response(&mut self, _: u32, _: usize, body_size: usize, _: usize) {
         if let Some(body) = self.get_http_call_response_body(0, body_size) {
-            #[allow(unknown_lints)]
-            #[allow(clippy::manual_is_multiple_of)]
+            #[allow(unknown_lints, clippy::manual_is_multiple_of)]
             if !body.is_empty() && body[0] % 2 == 0 {
                 info!("Access granted.");
                 self.resume_http_request();

--- a/examples/http_auth_random/src/lib.rs
+++ b/examples/http_auth_random/src/lib.rs
@@ -50,6 +50,7 @@ impl HttpContext for HttpAuthRandom {
 impl Context for HttpAuthRandom {
     fn on_http_call_response(&mut self, _: u32, _: usize, body_size: usize, _: usize) {
         if let Some(body) = self.get_http_call_response_body(0, body_size) {
+            #[allow(clippy::manual_is_multiple_of)]
             if !body.is_empty() && body[0] % 2 == 0 {
                 info!("Access granted.");
                 self.resume_http_request();


### PR DESCRIPTION
unsigned_is_multiple_of() was stabilized very recently, and while
the suggested code might be more idiomatic, it's not supported by
our MSRV or even the stable version currently used in rules_rust.