### PR TITLE
Ignore hashbrown in outdated checks.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -349,9 +349,10 @@ jobs:
       run: |
         cargo install cargo-outdated --version 0.17.0
 
+    # Unignore hashbrown once our MSRV is Rust v1.85+.
     - name: Run cargo outdated (main)
       run: |
-        cargo outdated --root-deps-only --exit-code 1
+        cargo outdated --root-deps-only --exit-code 1 --ignore hashbrown
 
     - name: Run cargo outdated (examples)
       run: |


### PR DESCRIPTION
The latest version of hashbrown requires a significant MSRV update
from Rust v1.68.0 (2023-03-09) to Rust v1.85.0 (2025-02-20), which
we want to postpone, so let's ignore it for the time being.